### PR TITLE
Make all paths relative in the frontend

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -32,11 +32,9 @@
     </div>
     <script>
       function loadUrl() {
-        var baseUrl = window.location.origin;
-        var searchInput = document.getElementById("search-input").value;
+        const searchInput = document.getElementById("search-input").value;
         if (searchInput) {
-          window.location.href =
-            baseUrl + "/" + encodeURIComponent(searchInput);
+          window.location.href = "./" + encodeURIComponent(searchInput);
         }
       }
 

--- a/assets/run_info/run_info.js
+++ b/assets/run_info/run_info.js
@@ -9,7 +9,9 @@ document.querySelectorAll(".dropdown-menu a").forEach(function (element) {
   }
 });
 
-const ws = new WebSocket("ws://" + window.location.host + "/ws");
+const loc = window.location;
+const protocol = loc.protocol === "https:" ? "wss:" : "ws:";
+const ws = new WebSocket(protocol + "//" + loc.host + loc.pathname + "/../ws");
 
 ws.onopen = function () {
   button = document.getElementById("downloadButton");
@@ -38,7 +40,7 @@ ws.onmessage = function (event) {
         output.textContent += msg.response.Error + "\n";
       } else if (msg.response.DownloadJWT) {
         var a = document.createElement("a");
-        a.href = "/download/" + msg.response.DownloadJWT;
+        a.href = "./download/" + msg.response.DownloadJWT;
         a.setAttribute("download", "");
         a.click();
 
@@ -50,9 +52,10 @@ ws.onmessage = function (event) {
 };
 
 function loadUrl() {
-  var baseUrl = window.location.origin;
-  var searchInput = document.getElementById("search-input").value;
-  window.location.href = baseUrl + "/" + encodeURIComponent(searchInput);
+  const searchInput = document.getElementById("search-input").value;
+  if (searchInput) {
+    window.location.href = "./" + encodeURIComponent(searchInput);
+  }
 }
 
 document.getElementById("load-button").addEventListener("click", loadUrl);

--- a/templates/run_info.html
+++ b/templates/run_info.html
@@ -598,7 +598,7 @@
     <script>
       var var_run_number = {{ run_number }};
     </script>
-    <script src="../assets/run_info/run_info.js"></script>
+    <script src="./assets/run_info/run_info.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"


### PR DESCRIPTION
- Make all paths relative.
- Correctly choose `wss` or `ws` depending on the protocol.

This is makes the website work both locally or under a reverse proxy (with an arbitrary base path).